### PR TITLE
debug - add checked field in method Tasks.insert()

### DIFF
--- a/imports/api/tasks.js
+++ b/imports/api/tasks.js
@@ -29,6 +29,7 @@ Meteor.methods({
     Tasks.insert({
       text,
       createdAt: new Date(),
+      checked: false,
       owner: this.userId,
       username: Meteor.users.findOne(this.userId).username,
     });


### PR DESCRIPTION
You use the checked field behind the project, but forget to add it in the beginning of the method Task.insert(), which will lead to some errors.
