### PR TITLE
Remove ReactDOM.findDOMNode

### DIFF
--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -22,12 +22,12 @@ class App extends Component {
     event.preventDefault();
 
     // Find the text field via the React ref
-    const text = ReactDOM.findDOMNode(this.refs.textInput).value.trim();
+    const text = this.refs.textInput.value.trim();
 
     Meteor.call('tasks.insert', text);
 
     // Clear form
-    ReactDOM.findDOMNode(this.refs.textInput).value = '';
+    this.refs.textInput.value = '';
   }
 
   toggleHideCompleted() {


### PR DESCRIPTION
As mentioned in these docs https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html I think ReactDOM.findDOMNode is unnecessary here as one of the great benefits of using refs imo (please correct me if I'm wrong on this) is to not have to find the dom node manually.

If you think this is a meaningful change I would be happy to update the docs for the guide as well :)