### PR TITLE
added preventDefault to form

### DIFF
--- a/imports/ui/TaskForm.jsx
+++ b/imports/ui/TaskForm.jsx
@@ -1,26 +1,26 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 
 export const TaskForm = () => {
-  const [text, setText] = useState("");
+  const [text, setText] = useState('');
 
-  const handleSubmit = () => {
+  const handleSubmit = (e) => {
+    e.preventDefault();
     if (!text) return;
 
     Meteor.call('tasks.insert', text.trim());
 
-    setText("");
+    setText('');
   };
 
   return (
-    <form className="task-form" onSubmit={handleSubmit}>
+    <form className='task-form' onSubmit={(e) => handleSubmit(e)}>
       <input
-        type="text"
-        placeholder="Type to add new tasks"
+        type='text'
+        placeholder='Type to add new tasks'
         value={text}
         onChange={(e) => setText(e.target.value)}
       />
-
-      <button type="submit">Add Task</button>
+      <button type='submit'>Add Task</button>
     </form>
   );
 };


### PR DESCRIPTION
This fixes the issue that submitting the Add Task form would force a page refresh and not update the db properly.  Added a `preventDefault` to the `handleSubmit` function.  This should also be updated in the docs in 3.1 "Create Task Form"

Now the `TaskForm.jsx` is as follows:

```jsx
import React, { useState } from 'react';

export const TaskForm = () => {
  const [text, setText] = useState('');

  const handleSubmit = (e) => {
    e.preventDefault();
    if (!text) return;

    Meteor.call('tasks.insert', text.trim());

    setText('');
  };

  return (
    <form className='task-form' onSubmit={(e) => handleSubmit(e)}>
      <input
        type='text'
        placeholder='Type to add new tasks'
        value={text}
        onChange={(e) => setText(e.target.value)}
      />
      <button type='submit'>Add Task</button>
    </form>
  );
};
```